### PR TITLE
Make help string links consistent.

### DIFF
--- a/internal/o2o/rewrite/rewrite.go
+++ b/internal/o2o/rewrite/rewrite.go
@@ -66,8 +66,10 @@ func (*Cmd) Synopsis() string { return "Rewrite Go source code to use the Opaque
 // Usage implements subcommand.Command.
 func (*Cmd) Usage() string {
 	return `Usage: open2opaque rewrite -levels=yellow <target> [<target>...]
+For documentation, see:
 
-See http://godoc/3/net/proto2/go/open2opaque/open2opaque for documentation.
+	https://go.dev/blog/protobuf-opaque
+	https://protobuf.dev/reference/go/opaque-migration/
 
 Command-line flag documentation follows:
 `
@@ -192,7 +194,7 @@ func (cmd *Cmd) RewriteTargets(ctx context.Context, targets []string) error {
 		return err
 	}
 	if targetsKind == "unknown" {
-		return fmt.Errorf("could not detect target kind of %q - neither a blaze target, nor a .go file, nor a go package import path (see http://godoc/3/net/proto2/go/open2opaque/open2opaque for instructions)", targets[0])
+		return fmt.Errorf("could not detect target kind of %q - neither a blaze target, nor a .go file, nor a go package import path (see https://go.dev/blog/protobuf-opaque or https://protobuf.dev/reference/go/opaque-migration/ for instructions)", targets[0])
 	}
 
 	inputTypeUses := targetsKind == kindTypeUsages


### PR DESCRIPTION
[Commit 80fa400](https://github.com/golang/open2opaque/commit/80fa400570f8127c81022a92698e1618e10d34dd) corrected some "help links" but not others (if I run `open2opaque rewrite -h` I still see `godoc` based links).

This PR rectifies all other printed help links.

There is one other reference to a `godoc` based link within `ignore.go:47` which I have not touched.

```go
// LoadList loads an ignore list from files matching the provided glob pattern
// (see http://godoc/3/file/base/go/file#Match for the syntax definition).
func LoadList(pattern string) (*List, error) {
	matches, err := glob(pattern)
	if err != nil {
		return nil, err
// etc
```

Thanks!